### PR TITLE
In browser fs.existsSync is not available

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/staltz/ssb-conn-db.git"
   },
   "dependencies": {
-    "atomic-file": "^1.1.5",
+    "atomic-file": "^2.1.1",
     "debug": "~4.1.1",
     "multiserver-address": "~1.0.1",
     "pull-notify": "~0.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es5", "es2015", "es2016", "es2017"],
+    "lib": ["es5", "es2015", "es2016", "es2017", "dom"],
     "skipLibCheck": true,
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
This together with the has-network2 change allows me to run ssb-conn in the browser.

The upgrade to atomic-file is mostly to write the database in indexeddb instead of localstorage in the browser. 

While it is a bit dirty to read the file just to check that it exists, this is only done on startup, so I don't think it will be that big of a problem.