### PR TITLE
Fix crash in self-healing json on undefined input

### DIFF
--- a/src/atomic-file-codecs.ts
+++ b/src/atomic-file-codecs.ts
@@ -9,7 +9,7 @@ export const selfHealingJSONCodec = {
     return JSON.stringify(obj, null, 2);
   },
   decode: function(input: any) {
-    const str: string = input ? input.toString() : "";
+    if (!input) return {};
     const MAX_TRIM = 10;
     let foundCorruption = false;
     for (let i = 0; i < MAX_TRIM; i++) {

--- a/src/atomic-file-codecs.ts
+++ b/src/atomic-file-codecs.ts
@@ -9,7 +9,7 @@ export const selfHealingJSONCodec = {
     return JSON.stringify(obj, null, 2);
   },
   decode: function(input: any) {
-    const str: string = input.toString();
+    const str: string = input ? input.toString() : "";
     const MAX_TRIM = 10;
     let foundCorruption = false;
     for (let i = 0; i < MAX_TRIM; i++) {


### PR DESCRIPTION
In the browser, atomic-file-rw might give you undefined contents (empty db) and this will crash this healer function ;)